### PR TITLE
chore: update for the vivliostyle/cli latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "chalk": "^4.1.0",
-    "create-create-app": "^6.0.1",
+    "create-create-app": "^7.0.1",
     "execa": "^4.0.3"
   },
   "devDependencies": {

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -8,7 +8,7 @@
     "preview": "vivliostyle preview"
   },
   "dependencies": {
-    "@vivliostyle/cli": "next",
+    "@vivliostyle/cli": "latest",
     "{{theme.name}}": "^{{theme.version}}"
   },
   "license": "{{license}}",

--- a/templates/default/vivliostyle.config.js
+++ b/templates/default/vivliostyle.config.js
@@ -1,20 +1,28 @@
 module.exports = {
-  title: '{{name}}', // populated into `manifest.json`, default to `title` of the first entry or `name` in `package.json`.
-  author: '{{contact}}', // default to `author` in `package.json` or undefined.
-  // language: 'ja', // default to `en`.
-  // size: 'A4', // paper size.
-  theme: '{{theme.name}}', // .css or local dir or npm package. default to undefined.
-  // entryContext: './manuscripts', // default to '.' (relative to `vivliostyle.config.js`).
+  title: '{{name}}', // populated into 'publication.json', default to 'title' of the first entry or 'name' in 'package.json'.
+  author: '{{contact}}', // default to 'author' in 'package.json' or undefined
+  // language: 'la',
+  // size: 'A4',
+  theme: '{{theme.name}}', // .css or local dir or npm package. default to undefined
   entry: [
-    'manuscript.md', // `title` is automatically guessed from the file (frontmatter > first heading).
+    // **required field**
+    'manuscript.md', // 'title' is automatically guessed from the file (frontmatter > first heading)
     // {
     //   path: 'epigraph.md',
-    //   title: 'Epigraph', // title can be overwritten (entry > file),
-    //   theme: '@vivliostyle/theme-whatever', // theme can be set indivisually. default to the root `theme`.
+    //   title: 'おわりに', // title can be overwritten (entry > file),
+    //   theme: '@vivliostyle/theme-whatever' // theme can be set indivisually. default to root 'theme'
     // },
-    // 'glossary.html', // html can be passed.
-  ], // `entry` can be `string` or `object` if there's only single markdown file.
-  // toc: true, // whether generate and include toc.html or not (does not affect manifest.json), default to `true`. if `string` given, use it as a custom toc.html.
+    // 'glossary.html' // html is also acceptable
+  ], // 'entry' can be 'string' or 'object' if there's only single markdown file
+  // entryContext: './manuscripts', // default to '.' (relative to 'vivliostyle.config.js')
+  // output: [ // path to generate draft file(s). default to '{title}.pdf'
+  //   './output.pdf', // the output format will be inferred from the name.
+  //   {
+  //     path: './book',
+  //     format: 'webpub',
+  //   },
+  // ],
+  // workspaceDir: '.vivliostyle', // directory which is saved intermediate files.
+  // toc: true, // whether generate and include ToC HTML or not, default to 'false'.
   // cover: './cover.png', // cover image. default to undefined.
-  // workDir: './dist', // default to `.vivliostyle`.
 }


### PR DESCRIPTION
- change in templates/default/package.json
  ```
      "@vivliostyle/cli": "next",
  ```
  to
  ```
      "@vivliostyle/cli": "latest",
  ```
  because the "next" version may be an old pre-release version (currently, v3.0.0-rc.1, older than the "latest" v3.0.1).

- update templates/default/vivliostyle.config.js