### PR TITLE
#19 Change the version of "@vivliostyle/cli" from "next" to "latest"

### DIFF
--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -8,7 +8,7 @@
     "preview": "vivliostyle preview"
   },
   "dependencies": {
-    "@vivliostyle/cli": "next",
+    "@vivliostyle/cli": "latest",
     "{{theme.name}}": "^{{theme.version}}"
   },
   "license": "{{license}}",


### PR DESCRIPTION
`templates/default` の `@vivliostyle/cli` 依存が `next` になっており、現行の `latest` ラインを取り込めなかった問題の修正です。これを踏まえて cli 側で `next` もリリースしていましたが、本修正により `latest` のみでよくなるはずです。

@MurakamiShinyu 
`package.json` のみの修正ですが、念の為にレビューをお願いします。