### PR TITLE
chor: add an empty test for release-it command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.6",
   "author": "Yasuaki Uechi <y@uechi.io>",
   "scripts": {
+    "test": "echo \"Test is not implemented\"",
     "build": "npm run tsup -- --minify",
     "clean": "shx rm -rf lib",
     "dev": "npm run tsup -- --watch",


### PR DESCRIPTION
#23 対応。`test` コマンドがないと `release-it` がエラーになる。設定ファイルから `test` 実行を消してもよいが、将来もしかするとテストが必要となるかもしれないので空の `echo` するだけの npm-scripts を追加しておく。