### PR TITLE
chore: Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,19 +40,19 @@
     "tsup": "tsup src/cli.ts -d lib"
   },
   "dependencies": {
-    "chalk": "^4.1.0",
-    "create-create-app": "^7.0.2",
-    "execa": "^5.0.0"
+    "chalk": "^4.1.2",
+    "create-create-app": "^7.1.0",
+    "execa": "^5.1.1"
   },
   "devDependencies": {
-    "@release-it/conventional-changelog": "^2.0.1",
-    "@types/node-fetch": "^2.5.8",
-    "husky": "^5.2.0",
-    "prettier": "^2.2.1",
-    "pretty-quick": "^3.1.0",
-    "release-it": "^14.5.0",
+    "@release-it/conventional-changelog": "^3.3.0",
+    "@types/node-fetch": "^3.0.2",
+    "husky": "^7.0.2",
+    "prettier": "^2.4.1",
+    "pretty-quick": "^3.1.1",
+    "release-it": "^14.11.6",
     "shx": "^0.3.3",
-    "tsup": "^4.8.21",
-    "typescript": "^4.2.3"
+    "tsup": "^5.2.1",
+    "typescript": "^4.4.3"
   }
 }


### PR DESCRIPTION
refs #30

依存を更新してみた。この状態で `npm pack` したものを `npm i` してから npm-scripts 上で `create-book sample` を定義して実行したところ正常に機能することを確認済み。