### PR TITLE
chore: Updated version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-book",
   "description": "The fastest way to start writing book with Vivliostyle ecosystem.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Vivliostyle Foundation",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
#30 で中途半端にエラーとなったが `npm publish` は成功して `0.3.2` がリリースされた。この状態だと `package.json` が `0.3.1` のままになるので次の `npm run release` が失敗するため解決するために手動でバージョン更新した。