### PR TITLE
chore: Reverted husky v7 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@release-it/conventional-changelog": "^3.3.0",
     "@types/node-fetch": "^3.0.2",
-    "husky": "^7.0.2",
+    "husky": "^4.3.8",
     "prettier": "^2.4.1",
     "pretty-quick": "^3.1.1",
     "release-it": "^14.11.6",


### PR DESCRIPTION
Since husky v6 or later is made into a shell script, cross-platform support becomes difficult due to problems such as environment variables.

Also v5 has a licensing issue. Therefore, I reverted to the latest v4.3.8 of the v4 series according to his other Vivliostyle projects.

refs #30