### PR TITLE
chore: `examples` always use the latest version of create-book

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -24,6 +24,6 @@
     "start": "create-book sample"
   },
   "dependencies": {
-    "create-book": "^0.3.3"
+    "create-book": "latest"
   }
 }


### PR DESCRIPTION
`examples` から参照する create-book は常に最新となるべきなので `dependencies` のバージョンを `latest` とする。