### PR TITLE
chore: Update a dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,17 +47,17 @@
     "upath": "^2.0.1"
   },
   "devDependencies": {
-    "@release-it/conventional-changelog": "^3.3.0",
-    "@types/jest": "^27.0.2",
-    "@types/node-fetch": "^3.0.2",
+    "@release-it/conventional-changelog": "^4.2.2",
+    "@types/jest": "^27.4.1",
+    "@types/node-fetch": "^2.6.1",
     "husky": "^4.3.8",
-    "jest": "^27.2.5",
-    "prettier": "^2.4.1",
-    "pretty-quick": "^3.1.1",
-    "release-it": "^14.11.6",
-    "shx": "^0.3.3",
-    "ts-jest": "^27.0.6",
-    "tsup": "^5.2.1",
-    "typescript": "^4.4.3"
+    "jest": "^27.5.1",
+    "prettier": "^2.6.0",
+    "pretty-quick": "^3.1.3",
+    "release-it": "^14.13.0",
+    "shx": "^0.3.4",
+    "ts-jest": "^27.1.3",
+    "tsup": "^5.12.1",
+    "typescript": "^4.6.2"
   }
 }


### PR DESCRIPTION
Versions with destructive changes, such as the ESM, are not updated.

husky が v5 でライセンス変更されたことを受けて v4 のままにしているが v6 で MIT に戻ったので更新してもよさそう。ただし今回は #50 反映を優先するため見送る。

- [husky(v4, v6) と simple-git-hooks どちらを使うべきか](https://zenn.dev/t28_tatsuya/articles/should-i-use-husky-or-simple-git-hook)