### PR TITLE
feat: Supported lower limit has been raised to Node.js v14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Vivliostyle Foundation",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "bin": "lib/cli.js",
   "keywords": [


### PR DESCRIPTION
refs #52
Node.js v12 の LTS が終了して v14 へ移行した。あわせて create-book が依存する npm、特に Vivlostyle 系もサポート下限を v14 へ移行することになっているので本プロジェクトもそれに従う。