### PR TITLE
chore: Targeted GitHub Actions to main and pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
デフォルト ブランチを `master` から `main` に変更。以前、開発者会議で `master` のままでゆくと話したが

- GitHub Actions を GitHub で既定が `main` となって以降の他プロジェクト間で流用しやすくしたい
- 個人的な観測範囲で `master` のままにしているプロジェクトが減っている、移行 or 新規作成と思われる

という理由から方針を転換した。あわせて GitHub Actions も `main` への push と PR に対してテスト実行するように変更。