### PR TITLE
chore: Update `.gitignore` from github/gitignore (ver. 23 Dec 2021)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-/lib
-package-lock.json
-yarn.lock
-
-# Created by https://www.gitignore.io/api/node
-# Edit at https://www.gitignore.io/?templates=node
-
-### Node ###
 # Logs
 logs
 *.log
@@ -13,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+.pnpm-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
@@ -49,8 +42,8 @@ build/Release
 node_modules/
 jspm_packages/
 
-# TypeScript v1 declaration files
-typings/
+# Snowpack dependency directory (https://snowpack.dev/)
+web_modules/
 
 # TypeScript cache
 *.tsbuildinfo
@@ -61,6 +54,15 @@ typings/
 # Optional eslint cache
 .eslintcache
 
+# Optional stylelint cache
+.stylelintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
 # Optional REPL history
 .node_repl_history
 
@@ -70,24 +72,40 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
+# dotenv environment variable files
 .env
-.env.test
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
+.parcel-cache
 
-# next.js build output
+# Next.js build output
 .next
+out
 
-# nuxt.js build output
+# Nuxt.js build / generate output
 .nuxt
+dist
 
-# react / gatsby 
-public/
+# Gatsby files
+.cache/
+# Comment in the public line in if your project uses Gatsby and not Next.js
+# https://nextjs.org/blog/next-9-1#public-directory-support
+# public
 
 # vuepress build output
 .vuepress/dist
+
+# vuepress v2.x temp and cache directory
+.temp
+.cache
+
+# Docusaurus cache and generated files
+.docusaurus
 
 # Serverless directories
 .serverless/
@@ -98,4 +116,20 @@ public/
 # DynamoDB Local files
 .dynamodb/
 
-# End of https://www.gitignore.io/api/node
+# TernJS port file
+.tern-port
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
+
+# yarn v2
+.yarn/cache
+.yarn/unplugged
+.yarn/build-state.yml
+.yarn/install-state.gz
+.pnp.*
+
+# Project
+package-lock.json
+yarn.lock
+lib/

--- a/templates/default/.gitignore
+++ b/templates/default/.gitignore
@@ -1,7 +1,3 @@
-# Created by https://www.toptal.com/developers/gitignore/api/node
-# Edit at https://www.toptal.com/developers/gitignore?templates=node
-
-### Node ###
 # Logs
 logs
 *.log
@@ -9,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+.pnpm-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
@@ -45,8 +42,8 @@ build/Release
 node_modules/
 jspm_packages/
 
-# TypeScript v1 declaration files
-typings/
+# Snowpack dependency directory (https://snowpack.dev/)
+web_modules/
 
 # TypeScript cache
 *.tsbuildinfo
@@ -56,6 +53,9 @@ typings/
 
 # Optional eslint cache
 .eslintcache
+
+# Optional stylelint cache
+.stylelintcache
 
 # Microbundle cache
 .rpt2_cache/
@@ -72,15 +72,20 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
+# dotenv environment variable files
 .env
-.env.test
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
+.parcel-cache
 
 # Next.js build output
 .next
+out
 
 # Nuxt.js build / generate output
 .nuxt
@@ -94,6 +99,13 @@ dist
 
 # vuepress build output
 .vuepress/dist
+
+# vuepress v2.x temp and cache directory
+.temp
+.cache
+
+# Docusaurus cache and generated files
+.docusaurus
 
 # Serverless directories
 .serverless/
@@ -110,4 +122,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
-# End of https://www.toptal.com/developers/gitignore/api/node
+# yarn v2
+.yarn/cache
+.yarn/unplugged
+.yarn/build-state.yml
+.yarn/install-state.gz
+.pnp.*


### PR DESCRIPTION
refs #11
開発者会議 June 2022 にて以下の方針が決定した。

- #11 を修正する
  - 以前は `npx` だけの問題だったが 2022/6 現在は `yarn` でも `.gitignore` 生成されない問題が発生するようになった
  - このファイルがないとエンド ユーザーが巨大な `node_modules` などを `git commit` する危険性がある
- `.gitignore` の内容は [gitignore/Node.gitignore at main · github/gitignore](https://github.com/github/gitignore/blob/main/Node.gitignore) の最新を反映
  - `templates/default/.gitignore` の内容は本プロジェクトを作成した当時の↑らしい
  - create-book として定義を決めるより、GitHub と世界中の開発者がメンテナンスしてる設定を採用するほうが安全性の面で好ましい
  - create-book が生成するプロジェクトは Vivliostyle CLI 向けなので、固有の除外設定が必要なら標準設定の末尾に追加する
  - 追加の際は `# Vivliostyle CLI` のようなコメントを書いて追記であることを明示したい

以上を踏まえて `.gitignore` を更新する。あわせて create-book 自身のものもこれを採用、固有定義は末尾へ移動させた。

なお現在のビルドだと `lib/` に Transpile 結果を出力しているが、これは `dist/` にしたい。後者は github/gitignore の定義に含まれており、一般的な Distribution Directory 名といえるので。