### PR TITLE
chore: update version for release it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-book",
   "description": "The fastest way to start writing book with Vivliostyle ecosystem.",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "author": "Vivliostyle Foundation",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
releae-it で v1.0.0 にしようとしたら動作がおかしくなり再実行できなくなったのでバージョン更新する。このバージョンではリリースしない。